### PR TITLE
Model Metrics, Cosmetic Changes, Beginning Random Forest Classifier 

### DIFF
--- a/Community_Tool.py
+++ b/Community_Tool.py
@@ -318,6 +318,7 @@ with tab4:
         y_sup = data
         y_sup = y_sup.dropna()
 
+        #TODO: Change to mutliselect?
         target_sup = st.selectbox('Choose Target',
                               options = y_sup.columns,
                               placeholder = 'Choose Option'
@@ -339,6 +340,7 @@ with tab4:
                 X = data[elements]
                 y = data[target]
 
+                #TODO: Figure out how many decimal places the c_values should accept
                 c_value = st.number_input('Input C Value', min_value=0.0,
                                           value = 1.0,
                                           step = 0.01,
@@ -346,13 +348,13 @@ with tab4:
 
 
                 kernel_type = st.selectbox('Select a kernel',
-                                           ('linear', 'poly', 'rbf'),
+                                           ('Linear', 'Polynomial', 'Radial Basis Function'),
                                            index=0)
                 st.write('You selected:', kernel_type)
 
                 #Sets degree to a default value in case kernel_type isn't polynomial and thus degree isn't declared
                 degree=3
-                if kernel_type == 'poly':
+                if kernel_type == 'Polynomial':
                     degree = st.number_input('Enter a degree', min_value=0)
 
 
@@ -362,7 +364,15 @@ with tab4:
                     #TODO Can add additional advanced settings
 
 
-                #creates svm model using inputted values
+                #changes the kernel_type var to a valid value for the svm function
+                if kernel_type == 'Linear':
+                    kernel_type = 'linear'
+                elif kernel_type == 'Polynomial':
+                    kernel_type = 'poly'
+                else:
+                    kernel_type = 'rbf'
+
+                # creates svm model using inputted values
                 svm = svm.SVC(C = c_value,
                               kernel = kernel_type,
                               degree = degree)

--- a/Community_Tool.py
+++ b/Community_Tool.py
@@ -329,7 +329,7 @@ with tab4:
                               'Regression'])
 
         if options_sup == 'Classification':
-            reg_alorigthm = st.selectbox(label = 'Choose Regression Algorithm',
+            class_alorigthm = st.selectbox(label = 'Choose Classification Algorithm',
                                   options = ['algorithm 1',
                                             'algorithm 2',
                                             'algorithm 3']

--- a/Community_Tool.py
+++ b/Community_Tool.py
@@ -20,10 +20,12 @@ from sklearn.decomposition import PCA
 from sklearn.model_selection import train_test_split, cross_val_score, RepeatedStratifiedKFold
 from sklearn.ensemble import VotingClassifier
 from sklearn.model_selection import GridSearchCV
-from sklearn.metrics import accuracy_score, confusion_matrix, classification_report, RocCurveDisplay, ConfusionMatrixDisplay
+from sklearn.metrics import accuracy_score, confusion_matrix, classification_report, RocCurveDisplay, \
+    ConfusionMatrixDisplay
 from sklearn.manifold import TSNE
 from imblearn.over_sampling import SMOTE
 from sklearn.multiclass import OneVsRestClassifier
+
 
 # Set Layout of the Application
 st.set_page_config(layout="wide")
@@ -34,16 +36,18 @@ tab1, tab2, tab3, tab4 = st.tabs(["About",
                                   "Data and Preprocessing",
                                   "Unsupervised Learning",
                                   "Supervised Learning"]
-                           )
+                                 )
 
 with tab1:
-    st.markdown("This application is designed to allow astrobiologists to experiment with machine learning approaches including unsupervised and "
-                "supervised methods using their own data."
-                " This application will be especially useful for those who may be interested in applying machine learning but either don't know "
-                "where to start or do not have the time to learn programming languages.")
+    st.markdown(
+        "This application is designed to allow astrobiologists to experiment with machine learning approaches including unsupervised and "
+        "supervised methods using their own data."
+        " This application will be especially useful for those who may be interested in applying machine learning but either don't know "
+        "where to start or do not have the time to learn programming languages.")
 
-    st.markdown('Developed by Floyd Nichols')
-    st.markdown('email: floydnichols@vt.edu')
+    st.markdown('Developed by Floyd Nichols and Grant Major')
+    st.markdown('email: floydnichols@vt.edu\n\n'
+                'email: grantmajor@vt.edu')
 
 with tab2:
     st.subheader("Upload a Data File")
@@ -52,12 +56,13 @@ with tab2:
     if uploaded_file is None:
         st.error('Need to upload a file')
     else:
-        def load_data(nrows):
-         data = pd.read_csv(uploaded_file, nrows=nrows)
-         return data
+        def load_data(data_file, nrows):
+            data = pd.read_csv(data_file, nrows=nrows)
+            return data
+
 
         data_load_state = st.text('Loading data...')
-        data = load_data(10000)
+        data = load_data(uploaded_file, 10000)
         data_load_state.text("Done!")
 
         if st.checkbox('Show Data'):
@@ -66,11 +71,12 @@ with tab2:
 
     st.divider()
     # Access and Download Example Data
-    st.subheader('If you do not have data of your own, use the following link to access available training sets from NASA AI Astrobiology')
+    st.subheader(
+        'If you do not have data of your own, use the following link to access available training sets from NASA AI Astrobiology')
     st.link_button('Go to NASA AI Astrobiology', 'https://ahed.nasa.gov/')
 
 with tab3:
-    col1, col2 = st.columns([1,1])
+    col1, col2 = st.columns([1, 1])
 
     # Test code to make sure that a data file is uploaded before continuing
     try:
@@ -93,20 +99,20 @@ with tab3:
         X = X.dropna()
 
         elements = st.multiselect("Select Explanatory Variables (default is all numerical columns):",
-                                X.columns,
-                                default = X.columns
-                                )
+                                  X.columns,
+                                  default=X.columns
+                                  )
 
         y = data
         y = y.dropna()
 
         target = st.selectbox('Choose Target',
-                              options = y.columns,
+                              options=y.columns,
                               )
 
         options = st.selectbox(label='Select Dimensionality Reduction Method',
-                     options=['Standard PCA',
-                              't-SNE'])
+                               options=['Standard PCA',
+                                        't-SNE'])
 
         # t-SNE Construction
         st.divider()
@@ -120,35 +126,35 @@ with tab3:
             y = y[target]
 
             n_components = st.number_input('Insert Number of Components',
-                                            min_value=2
-                                                )
+                                           min_value=2
+                                           )
             perplexity = st.number_input('Insert Perplexity',
-                                            min_value=2
-                                                )
+                                         min_value=2
+                                         )
             tsne = TSNE(n_components,
-                        random_state = 42,
+                        random_state=42,
                         perplexity=perplexity,
                         n_jobs=-1,
                         method='exact',
                         max_iter=5000
                         )
             tsne_result = tsne.fit_transform(X)
-            tsne_result_df = pd.DataFrame({'tsne_1': tsne_result[:,0],
-                                            'tsne_2': tsne_result[:,1]}
-                                        )
+            tsne_result_df = pd.DataFrame({'tsne_1': tsne_result[:, 0],
+                                           'tsne_2': tsne_result[:, 1]}
+                                          )
 
             # DBSCAN
             st.divider()
             clusters = st.selectbox(label='Select Cluster Method',
-                                   options=['Kmeans',
-                                            'DBSCAN',
-                                            'Target'])
+                                    options=['Kmeans',
+                                             'DBSCAN',
+                                             'Target'])
 
             if clusters == 'Kmeans':
                 st.subheader('Define K-means Parameters')
                 n_clusters = st.number_input('Enter Number of Clusters',
-                                      min_value=2
-                                      )
+                                             min_value=2
+                                             )
 
                 X_Kmeans = KMeans(n_clusters=n_clusters).fit(tsne_result)
                 labels = X_Kmeans.labels_
@@ -156,11 +162,11 @@ with tab3:
             elif clusters == 'DBSCAN':
                 st.subheader('Define DBSCAN Parameters')
                 eps = st.number_input('Enter Eps',
-                                        min_value=0.5
-                                            )
+                                      min_value=0.5
+                                      )
                 min_samples = st.number_input('Enter Minimum Samples',
-                                                min_value=1
-                                                    )
+                                              min_value=1
+                                              )
 
                 X_DBSCAN = DBSCAN(eps=eps, min_samples=min_samples).fit(tsne_result)
                 DBSCAN_labels = X_DBSCAN.labels_
@@ -175,11 +181,11 @@ with tab3:
                 st.subheader('t-Distributed Stochastic Neighbor Embedding')
                 fig, ax = plt.subplots()
                 fig = px.scatter(tsne_result_df,
-                                x='tsne_1',
-                                y='tsne_2',
-                                color = labels,
-                                title=options
-                            )
+                                 x='tsne_1',
+                                 y='tsne_2',
+                                 color=labels,
+                                 title=options
+                                 )
                 fig.update_traces(
                     marker=dict(size=8,
                                 line=dict(width=2,
@@ -190,9 +196,9 @@ with tab3:
                 ax.set_ylabel('t-SNE 2')
                 ax.set_aspect('auto')
                 ax.legend('Cluster',
-                            bbox_to_anchor=(0.8, 0.95),
-                            loc=2,
-                            borderaxespad=0.0)
+                          bbox_to_anchor=(0.8, 0.95),
+                          loc=2,
+                          borderaxespad=0.0)
                 st.plotly_chart(fig, use_container_width=True)
 
         else:
@@ -201,8 +207,8 @@ with tab3:
             y = y[target]
 
             n_components = st.number_input('Insert Number of Components',
-                                         min_value=2
-                                        )
+                                           min_value=2
+                                           )
 
             pca = PCA(n_components=n_components)
             pipe = Pipeline([('scaler', StandardScaler()),
@@ -273,20 +279,20 @@ with tab3:
                 fig, ax = plt.subplots()
                 exp_var_pca = pca.explained_variance_ratio_
                 fig = px.bar(exp_var_pca,
-                                 x=range(0, len(exp_var_pca)),
-                                 y=exp_var_pca,
-                                 title='PCA Explained Variance Ratio')
+                             x=range(0, len(exp_var_pca)),
+                             y=exp_var_pca,
+                             title='PCA Explained Variance Ratio')
 
                 fig.update_traces(
-                    marker=dict(color = 'grey',
-                                              line=dict(width=3,
-                                                        color='Black')
-                                              )
-                                  )
+                    marker=dict(color='grey',
+                                line=dict(width=3,
+                                          color='Black')
+                                )
+                )
 
                 fig.update_layout(
-                    xaxis_title = 'Principal Component Index',
-                    yaxis_title = 'Explained Variance Ratio'
+                    xaxis_title='Principal Component Index',
+                    yaxis_title='Explained Variance Ratio'
                 )
                 ax.set_aspect('auto')
                 ax.legend(bbox_to_anchor=(0.8, 0.95),
@@ -310,58 +316,80 @@ with tab4:
         X_sup = X.dropna()
 
         elements_sup = st.multiselect("Select Explanatory Variables (default is all numerical columns):",
-                                X_sup.columns,
-                                placeholder = 'Choose Option',
-                                # default = X_sup.columns,
-                                )
+                                      X_sup.columns,
+                                      placeholder='Choose Option',
+                                      default = X_sup.columns,
+                                      )
 
         y_sup = data
         y_sup = y_sup.dropna()
 
-        #TODO: Change to mutliselect?
+        #TODO: Make it so that the last column is the target variable automatically
         target_sup = st.selectbox('Choose Target',
-                              options = y_sup.columns,
-                              placeholder = 'Choose Option'
-                              )
-
-## Grant will work on this section ##
-        #TODO: Make it so that an error message appears when no data file is uploaded
-        options_sup = st.selectbox(label='Select Prediction Type',
-                     options=['Classification',
-                              'Regression'])
-
-        if options_sup == 'Classification':
-            class_algorithim = st.selectbox(label = 'Choose Classification Algorithm',
-                                  options = ['Support Vector Machine (SVM)',
-                                            'k-Nearest Neighbors (k-NN)',
-                                            'algorithm 3']
+                                  options=y_sup.columns,
+                                  placeholder='Choose Option'
                                   )
+
+        ## Grant will work on this section ##
+        #TODO: Make it so that an error message appears when no data file is uploaded
+
+        #CLASSIFICATION CODE: ------------------------------------------------------------------------------------------
+
+        #setting variable to None to prevent errors from undeclared variables:
+        class_algorithim = None
+        X_predictions = None
+        predicting_data = None
+
+        options_sup = st.selectbox(label='Select Prediction Type',
+                                   options=['Classification',
+                                            'Regression'])
+
+
+        #BEGIN TRAIN TEST SPLIT SECTION
+        st.subheader('Train Test Split: ')
+        train_proportion = st.number_input('Enter the proportion of data to be allocated to training.',
+                                           min_value=0.0,
+                                           value = 0.75,
+                                           step = 0.01,
+                                           format = "%.2f")
+        X_train, X_test, y_train, y_test = train_test_split(X,y, train_size=train_proportion)
+
+        st.divider()
+        #END TRAIN TEST SPLIT SECTION
+
+        #BEGIN MODEL SELECTION SECTION
+        if options_sup == 'Classification':
+            class_algorithim = st.selectbox(label='Choose Classification Algorithm',
+                                            options=['Support Vector Machine (SVM)',
+                                                     'k-Nearest Neighbors (k-NN)',
+                                                     'algorithm 3']
+                                            )
             if class_algorithim == 'Support Vector Machine (SVM)':
-                X = data[elements]
-                y = data[target]
+                X = data[elements_sup]
+                y = data[target_sup]
+                #Sets degree to a default value in case kernel_type isn't polynomial and thus degree isn't declared
+                degree = 3
 
-                #TODO: Figure out how many decimal places the c_values should accept
+                #Selecting C value hyperparameter
                 c_value = st.number_input('Input C Value', min_value=0.0,
-                                          value = 1.0,
-                                          step = 0.01,
-                                          format = "%.2f",)
+                                          value=1.0,
+                                          step=0.01,
+                                          format="%.2f")
 
-
+                #Selecting Kernel hyperparameter
                 kernel_type = st.selectbox('Select a kernel',
                                            ('Linear', 'Polynomial', 'Radial Basis Function'),
                                            index=0)
                 st.write('You selected:', kernel_type)
 
-                #Sets degree to a default value in case kernel_type isn't polynomial and thus degree isn't declared
-                degree=3
+                #Selecting Degree hyperparameter
                 if kernel_type == 'Polynomial':
                     degree = st.number_input('Enter a degree', min_value=0)
 
 
+                #TODO Can add additional advanced settings
                 #advanced_settings = st.checkbox('Enable advanced settings', value = False,)
-
                 #if advanced_settings:
-                    #TODO Can add additional advanced settings
 
 
                 #changes the kernel_type var to a valid value for the svm function
@@ -373,31 +401,68 @@ with tab4:
                     kernel_type = 'rbf'
 
                 # creates svm model using inputted values
-                svm = svm.SVC(C = c_value,
-                              kernel = kernel_type,
-                              degree = degree)
+                support_vector_machine = svm.SVC(C=c_value,
+                                                 kernel=kernel_type,
+                                                 degree=degree)
 
-                #TODO check if its transform fit or just fit
-                svm_result = svm.fit(X,y)
-
-
+                selected_model = support_vector_machine
 
 
             #TODO Finish implementation of k-NN
             elif class_algorithim == 'k-Nearest Neighbors (k-NN)':
 
-                k_value = st.number_input('Input k value.', min_value = 1, value = 1,)
+                k_value = st.number_input('Input k value.', min_value=1, value=1, )
 
                 knn = KNeighborsClassifier(n_neighbors=k_value)
+                selected_model = knn
+
+
+            #fits the selected model to the training data obtained from train_test_split
+            selected_model.fit(X_train, y_train)
+
+
+    #TODO: Check for common variable in Unsupervised section
+    #TODO: Move prediction data below metrics
+    #BEGIN MODEL METRICS SECTION
+    with col2:
+
+        #Reads in data file that user wants predictions on
+        predicting_data_file = st.file_uploader('Upload a file with values to be predicted.')
+
+        if predicting_data_file is None:
+            st.error('Need to upload a prediction file.')
+        else:
+            data_load_state2 = st.text('Loading data....')
+            predicting_data = load_data(predicting_data_file, 10000)
+            data_load_state2.text('Done!')
+
+
+        st.divider()
+        st.header("Model Performance Metrics")
+
+        #BEGIN CLASSIFICATION REPORT CODE
+        st.subheader("Classification Report:")
+
+        y_predictions = selected_model.predict(X_test)
+    #model.classes for labels
+        class_report = classification_report(y_test, y_predictions, output_dict=True)
+        st.text(class_report)
+        class_report = pd.DataFrame(class_report)
+        class_report_fig = sns.heatmap(class_report)
+
+
+        st.pyplot(class_report_fig.get_figure())
+        st.divider()
+        #END CLASSIFICATION REPORT CODE
+
+        #BEGIN CONFUSION MATRIX CODE
+        st.subheader("Confusion Matrix:")
+        conf_mat = confusion_matrix(y_test, y_predictions)
+        st.text(conf_mat)
+        conf_mat_fig = sns.heatmap(conf_mat)
+        st.pyplot(conf_mat_fig.get_figure())
+        #END CONFUSION MATRIX CODE
 
 
 
-
-
-
-
-
-
-
-    # with col2:
 

--- a/Community_Tool.py
+++ b/Community_Tool.py
@@ -325,15 +325,43 @@ with tab4:
 
 ## Grant will work on this section ##
         options_sup = st.selectbox(label='Select Prediction Type',
-                     options=['Classifier',
+                     options=['Classification',
                               'Regression'])
 
         if options_sup == 'Classification':
-            class_alorigthm = st.selectbox(label = 'Choose Classification Algorithm',
-                                  options = ['algorithm 1',
+            class_algorithim = st.selectbox(label = 'Choose Classification Algorithm',
+                                  options = ['Support Vector Machine (SVM)',
                                             'algorithm 2',
                                             'algorithm 3']
                                   )
+            if class_algorithim == 'Support Vector Machine (SVM)':
+                X = X[elements]
+                y = y[target]
+
+                c_value = st.number_input('Input C Value',
+                                          min_value=0)
+
+                kernel_type = st.selectbox('Select a kernel',
+                                           ('linear', 'poly', 'rbf'),
+                                           index=None)
+                st.write('You selected:', kernel_type)
+
+                #Sets degree to a default value in case kernel_type isnt polynomial and thus degree isn't declared
+                degree=3
+                if kernel_type == 'poly':
+                    degree = st.number_input('Enter a degree', min_value=0)
+
+                svm = svm.SVC(C = c_value,
+                              kernel = kernel_type,
+                              degree = degree)
+
+                #CHECK IF fit or fit_transform
+                svm_result = svm.fit(X)
+
+
+
+
+
 
     # with col2:
 

--- a/Community_Tool.py
+++ b/Community_Tool.py
@@ -307,6 +307,7 @@ with tab4:
         st.subheader('**Here, the user can employ regression and classification methods.**')
         st.divider()
 
+
         # Remove Columns that are Strings
         X_sup = data.select_dtypes(include=['int64', 'float64'])
 
@@ -346,13 +347,16 @@ with tab4:
 
 
         #BEGIN TRAIN TEST SPLIT SECTION
+
+        X_sup = X_sup[elements_sup]
+        y_sup = y_sup[target_sup]
         st.subheader('Train Test Split: ')
         train_proportion = st.number_input('Enter the proportion of data to be allocated to training.',
                                            min_value=0.0,
                                            value = 0.75,
                                            step = 0.01,
                                            format = "%.2f")
-        X_train, X_test, y_train, y_test = train_test_split(X,y, train_size=train_proportion)
+        X_train, X_test, y_train, y_test = train_test_split(X_sup,y_sup, train_size=train_proportion)
 
         st.divider()
         #END TRAIN TEST SPLIT SECTION
@@ -365,8 +369,6 @@ with tab4:
                                                      'algorithm 3']
                                             )
             if class_algorithim == 'Support Vector Machine (SVM)':
-                X = data[elements_sup]
-                y = data[target_sup]
                 #Sets degree to a default value in case kernel_type isn't polynomial and thus degree isn't declared
                 degree = 3
 
@@ -426,6 +428,60 @@ with tab4:
     #BEGIN MODEL METRICS SECTION
     with col2:
 
+
+        st.header("Model Performance Metrics")
+
+        #BEGIN CLASSIFICATION REPORT CODE
+        st.subheader("Classification Report:")
+
+        y_predictions = selected_model.predict(X_test)
+
+
+        class_report = classification_report(y_test, y_predictions, output_dict=False)
+        st.text(class_report)
+
+
+        #END CLASSIFICATION REPORT CODE
+
+
+        #BEGIN CONFUSION MATRIX CODE
+
+        #Creates confusion matrix
+        conf_mat = confusion_matrix(y_test, y_predictions)
+
+        #Makes a new section for the confusion matrix figure
+        st.subheader("Confusion Matrix:")
+
+        #Makes labels with number of each outcome
+        conf_mat_labels = [
+            f'True Negative\n{conf_mat[0, 0]}',
+            f'False Positive\n{conf_mat[0, 1]}',
+            f'False Negative\n{conf_mat[1, 0]}',
+            f'True Positive\n{conf_mat[1, 1]}'
+        ]
+
+        #gets rid of imperfections in the figure
+        plt.close('all')
+
+        #reshapes labels to 2x2 for confusion matrix labelling
+        conf_mat_labels = np.asarray(conf_mat_labels).reshape(2,2)
+
+        #creates the figure with the labels and using a purple color scheme
+        conf_mat_fig = sns.heatmap(conf_mat,
+                                   annot=conf_mat_labels,
+                                   fmt = '',
+                                   cmap='Purples',
+                                   cbar = True)
+
+        #shows the figure in streamlit
+        st.pyplot(conf_mat_fig.get_figure())
+
+        #END CONFUSION MATRIX CODE
+
+
+        #BEGIN PREDICTION UPLOAD CODE
+        st.divider()
+
         #Reads in data file that user wants predictions on
         predicting_data_file = st.file_uploader('Upload a file with values to be predicted.')
 
@@ -436,32 +492,9 @@ with tab4:
             predicting_data = load_data(predicting_data_file, 10000)
             data_load_state2.text('Done!')
 
-
-        st.divider()
-        st.header("Model Performance Metrics")
-
-        #BEGIN CLASSIFICATION REPORT CODE
-        st.subheader("Classification Report:")
-
-        y_predictions = selected_model.predict(X_test)
-    #model.classes for labels
-        class_report = classification_report(y_test, y_predictions, output_dict=True)
-        st.text(class_report)
-        class_report = pd.DataFrame(class_report)
-        class_report_fig = sns.heatmap(class_report)
+        #END PREDICTION UPLOAD CODE
 
 
-        st.pyplot(class_report_fig.get_figure())
-        st.divider()
-        #END CLASSIFICATION REPORT CODE
-
-        #BEGIN CONFUSION MATRIX CODE
-        st.subheader("Confusion Matrix:")
-        conf_mat = confusion_matrix(y_test, y_predictions)
-        st.text(conf_mat)
-        conf_mat_fig = sns.heatmap(conf_mat)
-        st.pyplot(conf_mat_fig.get_figure())
-        #END CONFUSION MATRIX CODE
 
 
 

--- a/Community_Tool.py
+++ b/Community_Tool.py
@@ -332,7 +332,7 @@ with tab4:
         if options_sup == 'Classification':
             class_algorithim = st.selectbox(label = 'Choose Classification Algorithm',
                                   options = ['Support Vector Machine (SVM)',
-                                            'algorithm 2',
+                                            'k-Nearest Neighbors (k-NN)',
                                             'algorithm 3']
                                   )
             if class_algorithim == 'Support Vector Machine (SVM)':
@@ -356,6 +356,12 @@ with tab4:
                     degree = st.number_input('Enter a degree', min_value=0)
 
 
+                #advanced_settings = st.checkbox('Enable advanced settings', value = False,)
+
+                #if advanced_settings:
+                    #TODO Can add additional advanced settings
+
+
                 #creates svm model using inputted values
                 svm = svm.SVC(C = c_value,
                               kernel = kernel_type,
@@ -363,6 +369,18 @@ with tab4:
 
                 #TODO check if its transform fit or just fit
                 svm_result = svm.fit(X,y)
+
+
+
+
+            #TODO Finish implementation of k-NN
+            elif class_algorithim == 'k-Nearest Neighbors (k-NN)':
+
+                k_value = st.number_input('Input k value.', min_value = 1, value = 1,)
+
+                knn = KNeighborsClassifier(n_neighbors=k_value)
+
+
 
 
 

--- a/Community_Tool.py
+++ b/Community_Tool.py
@@ -66,7 +66,7 @@ with tab2:
 
     st.divider()
     # Access and Download Example Data
-    st.subheader('If you do not have data of your own, use the follwing link to access available training sets from NASA AI Astrobiology')
+    st.subheader('If you do not have data of your own, use the following link to access available training sets from NASA AI Astrobiology')
     st.link_button('Go to NASA AI Astrobiology', 'https://ahed.nasa.gov/')
 
 with tab3:

--- a/Community_Tool.py
+++ b/Community_Tool.py
@@ -324,6 +324,7 @@ with tab4:
                               )
 
 ## Grant will work on this section ##
+        #TODO: Make it so that an error message appears when no data file is uploaded
         options_sup = st.selectbox(label='Select Prediction Type',
                      options=['Classification',
                               'Regression'])
@@ -335,28 +336,35 @@ with tab4:
                                             'algorithm 3']
                                   )
             if class_algorithim == 'Support Vector Machine (SVM)':
-                X = X[elements]
-                y = y[target]
+                X = data[elements]
+                y = data[target]
 
-                c_value = st.number_input('Input C Value',
-                                          min_value=0)
+                c_value = st.number_input('Input C Value', min_value=0.0,
+                                          value = 1.0,
+                                          step = 0.01,
+                                          format = "%.2f",)
+
 
                 kernel_type = st.selectbox('Select a kernel',
                                            ('linear', 'poly', 'rbf'),
-                                           index=None)
+                                           index=0)
                 st.write('You selected:', kernel_type)
 
-                #Sets degree to a default value in case kernel_type isnt polynomial and thus degree isn't declared
+                #Sets degree to a default value in case kernel_type isn't polynomial and thus degree isn't declared
                 degree=3
                 if kernel_type == 'poly':
                     degree = st.number_input('Enter a degree', min_value=0)
 
+
+                #creates svm model using inputted values
                 svm = svm.SVC(C = c_value,
                               kernel = kernel_type,
                               degree = degree)
 
-                #CHECK IF fit or fit_transform
-                svm_result = svm.fit(X)
+                #TODO check if its transform fit or just fit
+                svm_result = svm.fit(X,y)
+
+
 
 
 

--- a/Community_Tool.py
+++ b/Community_Tool.py
@@ -346,11 +346,9 @@ with tab4:
                                             'Regression'])
 
 
-        #BEGIN TRAIN TEST SPLIT SECTION
-
+        #BEGIN TRAIN TEST SPLIT SECTION -------------------------------------------------------------------
         X_sup = X_sup[elements_sup]
         y_sup = y_sup[target_sup]
-        st.subheader('Train Test Split: ')
         train_proportion = st.number_input('Enter the proportion of data to be allocated to training.',
                                            min_value=0.0,
                                            value = 0.75,
@@ -359,14 +357,14 @@ with tab4:
         X_train, X_test, y_train, y_test = train_test_split(X_sup,y_sup, train_size=train_proportion)
 
         st.divider()
-        #END TRAIN TEST SPLIT SECTION
+        #END TRAIN TEST SPLIT SECTION ---------------------------------------------------------------------
 
-        #BEGIN MODEL SELECTION SECTION
+        #BEGIN MODEL SELECTION SECTION --------------------------------------------------------------------
         if options_sup == 'Classification':
             class_algorithim = st.selectbox(label='Choose Classification Algorithm',
                                             options=['Support Vector Machine (SVM)',
                                                      'k-Nearest Neighbors (k-NN)',
-                                                     'algorithm 3']
+                                                     'Random Forest Classifier']
                                             )
             if class_algorithim == 'Support Vector Machine (SVM)':
                 #Sets degree to a default value in case kernel_type isn't polynomial and thus degree isn't declared
@@ -403,54 +401,63 @@ with tab4:
                     kernel_type = 'rbf'
 
                 # creates svm model using inputted values
-                support_vector_machine = svm.SVC(C=c_value,
-                                                 kernel=kernel_type,
-                                                 degree=degree)
-
-                selected_model = support_vector_machine
+                selected_model = svm.SVC(C=c_value,
+                                         kernel=kernel_type,
+                                         degree=degree)
 
 
-            #TODO Finish implementation of k-NN
+
+
             elif class_algorithim == 'k-Nearest Neighbors (k-NN)':
 
-                k_value = st.number_input('Input k value.', min_value=1, value=1, )
+                k_value = st.number_input('Input k value.',
+                                          min_value=1,
+                                          value=1 )
 
                 knn = KNeighborsClassifier(n_neighbors=k_value)
                 selected_model = knn
+
+            elif class_algorithim == 'Random Forest Classifier':
+
+                #TODO: Add the rest of the parameters
+                num_estimators = st.number_input('Enter the number of estimators.',
+                                                 min_value = 1,
+                                                 value = 100)
+
+
+                selected_model = RandomForestClassifier(n_estimators=num_estimators)
 
 
             #fits the selected model to the training data obtained from train_test_split
             selected_model.fit(X_train, y_train)
 
+    #END MODEL SELECTION SECTION ------------------------------------------------------------------
 
-    #TODO: Check for common variable in Unsupervised section
-    #TODO: Move prediction data below metrics
+
     #BEGIN MODEL METRICS SECTION
     with col2:
 
-
-        st.header("Model Performance Metrics")
-
-        #BEGIN CLASSIFICATION REPORT CODE
-        st.subheader("Classification Report:")
-
+        #makes predictions on test data
         y_predictions = selected_model.predict(X_test)
 
+        #check box for showing model metrics
+        show_metrics_enabled = st.checkbox("Show Model Metrics")
+
+        if show_metrics_enabled:
+            st.header("Model Performance Metrics")
+
+        #BEGIN CLASSIFICATION REPORT CODE --------------------------------------------------------
 
         class_report = classification_report(y_test, y_predictions, output_dict=False)
-        st.text(class_report)
 
+        if show_metrics_enabled:
+            st.subheader("Classification Report:")
+            st.text(class_report)
+        #END CLASSIFICATION REPORT CODE -----------------------------------------------------------
 
-        #END CLASSIFICATION REPORT CODE
-
-
-        #BEGIN CONFUSION MATRIX CODE
-
+        #BEGIN CONFUSION MATRIX CODE --------------------------------------------------------------
         #Creates confusion matrix
         conf_mat = confusion_matrix(y_test, y_predictions)
-
-        #Makes a new section for the confusion matrix figure
-        st.subheader("Confusion Matrix:")
 
         #Makes labels with number of each outcome
         conf_mat_labels = [
@@ -466,21 +473,23 @@ with tab4:
         #reshapes labels to 2x2 for confusion matrix labelling
         conf_mat_labels = np.asarray(conf_mat_labels).reshape(2,2)
 
-        #creates the figure with the labels and using a purple color scheme
+        #creates the figure
         conf_mat_fig = sns.heatmap(conf_mat,
                                    annot=conf_mat_labels,
                                    fmt = '',
                                    cmap='Purples',
                                    cbar = True)
 
-        #shows the figure in streamlit
-        st.pyplot(conf_mat_fig.get_figure())
+        #shows the figure in streamlit if the checkbox is enabled
+        if show_metrics_enabled:
+            #Makes a new section for the confusion matrix figure
+            st.subheader("Confusion Matrix:")
+            st.pyplot(conf_mat_fig.get_figure())
+            st.divider()
+        #END CONFUSION MATRIX CODE -----------------------------------------------------------------
 
-        #END CONFUSION MATRIX CODE
+        #BEGIN PREDICTION UPLOAD CODE --------------------------------------------------------------
 
-
-        #BEGIN PREDICTION UPLOAD CODE
-        st.divider()
 
         #Reads in data file that user wants predictions on
         predicting_data_file = st.file_uploader('Upload a file with values to be predicted.')
@@ -492,10 +501,4 @@ with tab4:
             predicting_data = load_data(predicting_data_file, 10000)
             data_load_state2.text('Done!')
 
-        #END PREDICTION UPLOAD CODE
-
-
-
-
-
-
+        #END PREDICTION UPLOAD CODE ---------------------------------------------------------------


### PR DESCRIPTION
Fixed the supervised model training. Previously, the train test split function that supplied the training data was passed the wrong parameters. The classification report is now correctly displayed as a table. The confusion matrix is now displayed as a Seaborn heatmap. A checkbox was added to hide model metrics when not desired. Notably, model training is significantly faster after fixing the issue with the train test split function. Finally, a Random Forest Classifier option was added to the list of classification algorithms. Currently only n_estimators is available as a parameter.